### PR TITLE
Use module objects everywhere

### DIFF
--- a/src/components/AssemblyArea.vue
+++ b/src/components/AssemblyArea.vue
@@ -23,12 +23,7 @@ function handlePremadeSelect(assembly) {
   if (!assembly || !assembly.modules || assembly.modules.length === 0) {
     modules.currentAssembly.value = []
   } else {
-    // Convert string names to module objects
-    const mods = assembly.modules
-        .map(name => modules.availableModules.find(m => m.name === name))
-        .filter(Boolean)
-        .map(m => ({ ...m })) // shallow copy to avoid shared object issues
-    modules.currentAssembly.value = mods
+    modules.currentAssembly.value = assembly.modules.map(m => ({ ...m }))
   }
   closePremadeModal()
 }

--- a/src/components/subcomponents/AssemblyArea/ActiveAssemblyMenu.vue
+++ b/src/components/subcomponents/AssemblyArea/ActiveAssemblyMenu.vue
@@ -15,10 +15,7 @@ function selectAssembly(assembly) {
   modules.currentAssembly.splice(
       0,
       modules.currentAssembly.length,
-      ...assembly.modules
-          .map(name => modules.availableModules.find(mod => mod.name === name))
-          .filter(Boolean)
-          .map(mod => ({ ...mod }))
+      ...assembly.modules.map(mod => ({ ...mod }))
   )
   modules.editingAssemblyName = assembly.name || '' // Optionally track name
   modules.editingAssemblyId = assembly.id || null   // Optionally track id
@@ -42,8 +39,8 @@ function selectAssembly(assembly) {
       >
         <div class="assembly-name">{{ assembly.name || 'Assembly' }}</div>
         <ul class="modules-list">
-          <li v-for="mod in assembly.modules" :key="mod">
-            {{ typeof mod === 'string' ? mod : mod.name }}
+          <li v-for="mod in assembly.modules" :key="mod.name">
+            {{ mod.name }}
           </li>
         </ul>
       </div>

--- a/src/components/subcomponents/AssemblyArea/AssemblyWorkspace.vue
+++ b/src/components/subcomponents/AssemblyArea/AssemblyWorkspace.vue
@@ -12,7 +12,7 @@ function saveAssembly() {
   modules.activeAssemblies.push({
     id,
     name: name.value || 'Custom Assembly',
-    modules: [...modules.currentAssembly]
+    modules: modules.currentAssembly.map(m => ({ ...m }))
   })
   // Clear the workspace for next assembly
   modules.currentAssembly.splice(0)

--- a/src/components/subcomponents/AssemblyArea/ModulesMenu.vue
+++ b/src/components/subcomponents/AssemblyArea/ModulesMenu.vue
@@ -53,7 +53,7 @@ function addModuleToAssembly(moduleName) {
     showToast('You do not have any in stock.')
     return
   }
-  modules.currentAssembly.push(mod.name)
+  modules.currentAssembly.push({ ...mod })
   mod.count -= 1
   showToast(`Added ${mod.name} to assembly.`)
 }

--- a/src/components/subcomponents/AssemblyArea/PremadeAssembliesMenu.vue
+++ b/src/components/subcomponents/AssemblyArea/PremadeAssembliesMenu.vue
@@ -7,11 +7,7 @@ const modules = modulesStore()
 const premadeAssemblies = modules.premadeAssemblies
 
 function selectAssembly(assembly) {
-  // Convert names to module objects
-  const moduleObjs = assembly.modules
-      .map(name => modules.availableModules.find(m => m.name === name))
-      .filter(Boolean)
-      .map(m => ({ ...m })) // shallow copy, so editing one doesn't edit all
+  const moduleObjs = assembly.modules.map(m => ({ ...m }))
   modules.currentAssembly.splice(0, modules.currentAssembly.length, ...moduleObjs)
   emit('close')
 }
@@ -44,7 +40,7 @@ function close() {
         >
           <div class="assembly-usage">{{ assembly.usage }}</div>
           <ul class="modules-list">
-            <li v-for="mod in assembly.modules" :key="mod">{{ mod }}</li>
+            <li v-for="mod in assembly.modules" :key="mod.name">{{ mod.name }}</li>
           </ul>
         </div>
       </div>

--- a/src/components/subcomponents/MainMap/AssembliesMenu.vue
+++ b/src/components/subcomponents/MainMap/AssembliesMenu.vue
@@ -78,7 +78,7 @@ function confirmDeploy() {
           class="assemblyCard"
       >
         <ul class="modulesList">
-          <li v-for="mod in assembly.modules" :key="mod">
+          <li v-for="mod in assembly.modules" :key="mod.name">
             {{ mod.name }}
           </li>
         </ul>

--- a/src/components/subcomponents/MainMap/PlantsMenu.vue
+++ b/src/components/subcomponents/MainMap/PlantsMenu.vue
@@ -31,7 +31,7 @@ const availableTiles = computed(() => {
       // Only show empty tiles (no plant)
       if (!tile.plant && tile.assembly && tile.assembly.deployed) {
         // Require that one of the assembly's modules is a "Planter"
-        if (tile.assembly.modules.some(m => m.toLowerCase().includes('planter'))) {
+        if (tile.assembly.modules.some(mod => mod.name.toLowerCase().includes('planter'))) {
           result.push({row, col})
         }
       }
@@ -65,7 +65,7 @@ function confirmDeploy() {
   const row = Number(selectedRow.value) - 1
   const col = Number(selectedCol.value) - 1
   const tile = tiles.tiles[row][col]
-  if (!tile.plant && tile.assembly && tile.assembly.deployed && tile.assembly.modules.some(m => m.toLowerCase().includes('planter'))) {
+  if (!tile.plant && tile.assembly && tile.assembly.deployed && tile.assembly.modules.some(mod => mod.name.toLowerCase().includes('planter'))) {
     // Check user has enough gold
     if (user.gold < deployingPlant.value.cost) {
       alert("Not enough gold!")

--- a/src/components/subcomponents/MainMap/TilesGrid.vue
+++ b/src/components/subcomponents/MainMap/TilesGrid.vue
@@ -32,7 +32,8 @@ function plantIsRipe(tile) {
   return tile.plant && (tile.plant.growthStage === 'Mature' || tile.plant.growthStage === 'Overripe')
 }
 function hasCollector(tile) {
-  return tile.assembly && tile.assembly.modules.includes('Collector')
+  return tile.assembly &&
+      tile.assembly.modules.some(m => m.name && m.name.includes('Collector'))
 }
 function canHarvestPlant(tile) {
   return plantIsRipe(tile) && hasCollector(tile)
@@ -59,7 +60,8 @@ function getAnimalProduct(animal) {
   return animals.products.find(p => p.key === animal.product)
 }
 function canHarvestProduct(tile) {
-  return tile.assembly && tile.assembly.modules.includes('Collector')
+  return tile.assembly &&
+      tile.assembly.modules.some(m => m.name && m.name.includes('Collector'))
 }
 function harvestAnimalProduct(tile) {
   if (!canHarvestProduct(tile)) return
@@ -114,7 +116,7 @@ const canMoveAnimal = computed(() =>
     selectedTile.value &&
     selectedTile.value.animal &&
     selectedTile.value.assembly &&
-    selectedTile.value.assembly.modules.includes('Robotic Arm')
+    selectedTile.value.assembly.modules.some(m => m.name && m.name.toLowerCase().includes('robotic arm'))
 )
 function openMoveAnimalModal(tile) {
   animalToMove.value = tile.animal
@@ -256,7 +258,7 @@ function confirmMoveAnimal() {
         <strong>Assembly:</strong>
         <span class="tileAssembly">{{ selectedTile.assembly.icon || '🤖' }}</span>
         Modules:
-        <span v-for="mod in selectedTile.assembly.modules" :key="mod">{{ mod }} </span>
+        <span v-for="mod in selectedTile.assembly.modules" :key="mod.name">{{ mod.name }} </span>
         <button @click="recallAssembly(selectedTile)">Recall</button>
       </div>
       <div v-else style="margin-top: 0.7em;">

--- a/stores/modulesStore.js
+++ b/stores/modulesStore.js
@@ -757,12 +757,18 @@ export const modulesStore = defineStore('modules', () => {
         ]
     )
 
+    const findModule = name => availableModules.value.find(m => m.name === name)
+    const resolveModules = names => names
+        .map(n => findModule(n))
+        .filter(Boolean)
+        .map(m => ({ ...m }))
+
     const premadeAssemblies =
         [
             // === Produce Cultivation (Field Zone) ===
             {
                 usage: "Field Planter",
-                modules: [
+                modules: resolveModules([
                     "UGV Transport (small)",
                     "Battery Pack",
                     "GPS Module",
@@ -770,11 +776,11 @@ export const modulesStore = defineStore('modules', () => {
                     "Robotic Arm (medium)",
                     "Hole-Borer",
                     "Camera Module (RGB)"
-                ]
+                ])
             },
             {
                 usage: "Field Planter (seedlings)",
-                modules: [
+                modules: resolveModules([
                     "UGV Transport (small)",
                     "Battery Pack",
                     "GPS Module",
@@ -782,50 +788,50 @@ export const modulesStore = defineStore('modules', () => {
                     "Robotic Arm (medium)",
                     "Gripper",
                     "Camera Module (RGB)"
-                ]
+                ])
             },
             {
                 usage: "Weeding Assembly (Cutter)",
-                modules: [
+                modules: resolveModules([
                     "UGV Transport (small)",
                     "Battery Pack",
                     "Camera Module (RGB)",
                     "Cutter/Saw"
-                ]
+                ])
             },
             {
                 usage: "Weeding Assembly (Sprayer)",
-                modules: [
+                modules: resolveModules([
                     "UGV Transport (small)",
                     "Battery Pack",
                     "Camera Module (RGB)",
                     "Tank",
                     "Sprayer"
-                ]
+                ])
             },
             {
                 usage: "Irrigation Assembly (Spot)",
-                modules: [
+                modules: resolveModules([
                     "UGV Transport (small)",
                     "Battery Pack",
                     "Tank",
                     "Sprayer",
                     "Camera Module (RGB)"
-                ]
+                ])
             },
             // Fixed field irrigation not an assembly, but could be a:
             {
                 usage: "Field Irrigation Station",
-                modules: [
+                modules: resolveModules([
                     "Pole",
                     "Tank",
                     "Valve module",   // Note: Add to modules list if you want!
                     "Pump module"     // Note: Add to modules list if you want!
-                ]
+                ])
             },
             {
                 usage: "Harvesting Assembly",
-                modules: [
+                modules: resolveModules([
                     "UGV Transport (small)",
                     "Battery Pack",
                     "GPS Module",
@@ -834,12 +840,12 @@ export const modulesStore = defineStore('modules', () => {
                     "Gripper",
                     "Suction Tool",
                     "Cart"
-                ]
+                ])
             },
             // Sorting/grading is just extra modules on harvester:
             {
                 usage: "Harvest Grader",
-                modules: [
+                modules: resolveModules([
                     "UGV Transport (small)",
                     "Battery Pack",
                     "GPS Module",
@@ -847,82 +853,82 @@ export const modulesStore = defineStore('modules', () => {
                     "Camera Module (RGB)",
                     "Weighing module",   // Add to modules list if desired
                     "Cart"
-                ]
+                ])
             },
 
             // === Land Modification ===
             {
                 usage: "Path Construction",
-                modules: [
+                modules: resolveModules([
                     "UGV Transport (large)",
                     "Battery Pack",
                     "GPS Module",
                     "Digger",
                     "Flattener module",   // Add if needed
                     "Grader module"       // Add if needed
-                ]
+                ])
             },
 
             // === Rainwater Management ===
             {
                 usage: "Rain Capture Station",
-                modules: [
+                modules: resolveModules([
                     "Barrel", // Add if needed
                     "Valve module",        // Add if needed
                     "Pump module"          // Add if needed
-                ]
+                ])
             },
 
             // === Habitat Management ===
             {
                 usage: "Sensor Deployment UGV",
-                modules: [
+                modules: resolveModules([
                     "UGV Transport (small)",
                     "Battery Pack",
                     "Camera Module (RGB)",
                     "Sensor Module (soil)",
                     "GPS Module"
-                ]
+                ])
             },
             {
                 usage: "Sensor Deployment Drone",
-                modules: [
+                modules: resolveModules([
                     "Drone Transport (quadcopter)",
                     "Battery Pack",
                     "Camera Module (RGB)",
                     "Sensor Module (air)",
                     "GPS Module"
-                ]
+                ])
             },
             {
                 usage: "Fixed Sensor Pole",
-                modules: [
+                modules: resolveModules([
                     "Pole",
                     "Battery Pack",
                     "Sensor Module (soil)",
                     "Sensor Module (air)",
                     "Camera Module (RGB)"
-                ]
+                ])
             },
             {
                 usage: "Sheep Monitor/Fence",
-                modules: [
+                modules: resolveModules([
                     "Pole",
                     "Battery Pack",
                     "Camera Module (RGB)",
                     "Communications Repeater"
-                ]
+                ])
             },
             {
                 usage: "Sheep GPS Collar",
-                modules: [
+                modules: resolveModules([
                     "GPS Module"
                     // "Collar Module" (if defined)
-                ]
+                ])
             },
             {
                 usage: "Poultry/Egg Collector",
-                modules: [
+                modules: resolveModules([
                     "UGV Transport (small)",
                     "Battery Pack",
                     "Camera Module (RGB)",
@@ -930,13 +936,13 @@ export const modulesStore = defineStore('modules', () => {
                     "Suction Tool",
                     "Cart",
                     "Mycelium Box"
-                ]
+                ])
             },
 
             // === Bioreactor & Mycelium ===
             {
                 usage: "Bioreactor Assembly",
-                modules: [
+                modules: resolveModules([
                     "Internal space module", // Add to list if you want
                     "Static actuator",       // Add to list if you want
                     "Heating Module",
@@ -946,92 +952,92 @@ export const modulesStore = defineStore('modules', () => {
                     "Tank",
                     "Pressing module",       // Add to list if you want
                     "Generator module"       // Add to list if you want
-                ]
+                ])
             },
             {
                 usage: "Mycelium Bricks Production",
-                modules: [
+                modules: resolveModules([
                     "Internal space module",   // Add to list if you want
                     "Robotic Shelf",
                     "Spore spreading module",  // Add to list if you want
                     "Heater/Humidifier module",// Add to list if you want
                     "Sensor Module (air)",
                     "Pressing module"          // Add to list if you want
-                ]
+                ])
             },
 
             // === Maintenance/Assembly ===
             {
                 usage: "Module Assembly Station",
-                modules: [
+                modules: resolveModules([
                     "Robotic Shelf",
                     "Robotic Arm (heavy)",
                     "Rotary plate module",    // Add to list if you want
                     "Onboard Computer",
                     "Cart"
-                ]
+                ])
             },
 
             // === Infrastructure ===
             {
                 usage: "Communications Backbone",
-                modules: [
+                modules: resolveModules([
                     "Pole",
                     "Battery Pack",
                     "Communications Repeater"
-                ]
+                ])
             },
             {
                 usage: "Solar Charging Station",
-                modules: [
+                modules: resolveModules([
                     "Pole",
                     "Solar Panel",
                     "Battery Pack",
                     "Rotary plate module",   // Add to list if you want
                     "Onboard Computer"
-                ]
+                ])
             },
 
             // === Mapping/Monitoring Variants ===
             {
                 usage: "Topographic Mapping UGV",
-                modules: [
+                modules: resolveModules([
                     "UGV Transport (small)",
                     "Battery Pack",
                     "GPS Module",
                     "Camera Module (RGB)",
                     "Sensor Module (soil)",
                     "LIDAR module"           // Add to list if you want
-                ]
+                ])
             },
             {
                 usage: "Topographic Mapping Drone",
-                modules: [
+                modules: resolveModules([
                     "Drone Transport (quadcopter)",
                     "Battery Pack",
                     "GPS Module",
                     "Camera Module (RGB)",
                     "LIDAR module"           // Add to list if you want
-                ]
+                ])
             },
 
             // === Habitat & Sensor Deployment (LIDAR variant) ===
             {
                 usage: "Habitat LIDAR Mapping",
-                modules: [
+                modules: resolveModules([
                     "UGV Transport (small)",
                     "Battery Pack",
                     "LIDAR module",
                     "Camera Module (RGB)",
                     "Sensor Module (soil)",
                     "GPS Module"
-                ]
+                ])
             },
 
             // === Harvest/Monitor (LIDAR add-on) ===
             {
                 usage: "LIDAR Harvester",
-                modules: [
+                modules: resolveModules([
                     "UGV Transport (small)",
                     "Battery Pack",
                     "GPS Module",
@@ -1040,7 +1046,7 @@ export const modulesStore = defineStore('modules', () => {
                     "LIDAR module",
                     "Gripper",
                     "Cart"
-                ]
+                ])
             }
         ];
 
@@ -1049,19 +1055,19 @@ export const modulesStore = defineStore('modules', () => {
         [
         {
             id: 'a6be11ee-e3a0-4189-baef-c59dcd4953b6',
-            modules: [
+            modules: resolveModules([
                 "UGV Transport (small)",
                 "Battery Pack",
                 "LIDAR module",
                 "Camera Module (RGB)",
                 "Sensor Module (soil)",
                 "GPS Module"
-            ],
+            ]),
             name: "Test A",
             deployed: false
         },        {
             id:'65012c5e-0ef3-488f-98e4-3a4366b3eb17',
-            modules: [
+            modules: resolveModules([
                 "UGV Transport (small)",
                 "Battery Pack",
                 "Camera Module (RGB)",
@@ -1069,13 +1075,13 @@ export const modulesStore = defineStore('modules', () => {
                 "Suction Tool",
                 "Cart",
                 "Mycelium Box"
-            ],
+            ]),
             name: "Test B",
             deployed: true
         },
     ]
     )
 
-    const currentAssembly = []
+    const currentAssembly = ref([])
     return {availableModules, activeAssemblies, premadeAssemblies, currentAssembly}
 })


### PR DESCRIPTION
## Summary
- keep full module objects in all stores and components
- convert premade and active assemblies to store module objects
- update assembly menus and workspace to handle module objects
- update tile/plant logic to search modules by name

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c593ba9b4832799b76e194cd11e3d