### PR TITLE
Fix reactive update of currentAssembly

### DIFF
--- a/src/components/AssemblyArea.vue
+++ b/src/components/AssemblyArea.vue
@@ -21,9 +21,11 @@ function closePremadeModal() {
 function handlePremadeSelect(assembly) {
   // If blank, assembly will be null or empty
   if (!assembly || !assembly.modules || assembly.modules.length === 0) {
-    modules.currentAssembly.value = []
+    // Replace the entire array so reactivity triggers correctly
+    modules.currentAssembly = []
   } else {
-    modules.currentAssembly.value = assembly.modules.map(m => ({ ...m }))
+    // Deep copy modules and replace the array
+    modules.currentAssembly = assembly.modules.map(m => ({ ...m }))
   }
   closePremadeModal()
 }


### PR DESCRIPTION
## Summary
- update premade selection handler to replace `currentAssembly` via direct assignment

## Testing
- `npm run build`
- node script to verify assignment reflects in store

------
https://chatgpt.com/codex/tasks/task_e_686d34b63f308327934fa97f97329794