### PR TITLE
Fix UI overflow issues

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -27,11 +27,27 @@ onBeforeUnmount(() => {
 })
 </script>
 
-<template>
-  <main>
-    <StartingScreen v-if="currentScreen === 'start'"/>
-    <MainMap v-if="currentScreen === 'main'"  />
-    <AssemblyArea v-if="currentScreen === 'assembly'"/>
-    <MarketArea v-if="currentScreen === 'market'"/>
-  </main>
-</template>
+  <template>
+    <main>
+      <StartingScreen v-if="currentScreen === 'start'"/>
+      <MainMap v-if="currentScreen === 'main'"  />
+      <AssemblyArea v-if="currentScreen === 'assembly'"/>
+      <MarketArea v-if="currentScreen === 'market'"/>
+    </main>
+  </template>
+
+  <style>
+  html, body, #app {
+    margin: 0;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  main {
+    display: flex;
+    flex-direction: column;
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+  }
+  </style>

--- a/src/components/MainMap.vue
+++ b/src/components/MainMap.vue
@@ -36,15 +36,31 @@ const acceptedOrdersDisplay = computed(() =>
 
 </script>
 <template>
-  <StatusBar/>
-  <AssembliesMenu title="Available Assemblies"/>
-  <AnimalsMenu/>
-  <TilesGrid/>
-  <OrdersMenu :items="acceptedOrdersDisplay"/>
- <PlantsMenu/>
-
+  <div class="main-map-wrapper">
+    <StatusBar />
+    <AssembliesMenu title="Available Assemblies" />
+    <div class="center-area">
+      <AnimalsMenu />
+      <TilesGrid />
+      <PlantsMenu />
+    </div>
+    <OrdersMenu :items="acceptedOrdersDisplay" />
+  </div>
 </template>
 
 <style scoped>
+.main-map-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
 
-</style>
+.center-area {
+  flex: 1 1 auto;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: center;
+  overflow: hidden;
+}</style>

--- a/src/components/MarketArea.vue
+++ b/src/components/MarketArea.vue
@@ -3,11 +3,34 @@ import eventBus from "@/eventBus.js";
 </script>
 
 <template>
-  Market Area
-  <button @click="eventBus.emit('nav', 'main')">Return to Map</button>
-
+  <div class="market-area-main">
+    <div class="market-content">Market Area</div>
+    <button class="return-btn" @click="eventBus.emit('nav', 'main')">Return to Map</button>
+  </div>
 </template>
 
 <style scoped>
+.market-area-main {
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
 
-</style>
+.return-btn {
+  margin-top: 1.5em;
+  padding: 0.4em 1.2em;
+  border-radius: 8px;
+  border: none;
+  background: #80deea;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.return-btn:hover {
+  background: #00bcd4;
+  color: #fff;
+}</style>

--- a/src/components/subcomponents/MainMap/AnimalsMenu.vue
+++ b/src/components/subcomponents/MainMap/AnimalsMenu.vue
@@ -195,7 +195,7 @@ function confirmDeploy() {
   height: 60vh;
   display: flex;
   flex-direction: column;
-  float: left;
+  flex: 0 0 auto;
 }
 
 .verticalMenuScroll {
@@ -260,6 +260,9 @@ function confirmDeploy() {
   border-radius: 12px;
   box-shadow: 0 4px 24px #0002;
   min-width: 250px;
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 1em;

--- a/src/components/subcomponents/MainMap/AssembliesMenu.vue
+++ b/src/components/subcomponents/MainMap/AssembliesMenu.vue
@@ -197,6 +197,9 @@ function confirmDeploy() {
   border-radius: 12px;
   box-shadow: 0 4px 24px #0002;
   min-width: 250px;
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 1em;

--- a/src/components/subcomponents/MainMap/PlantsMenu.vue
+++ b/src/components/subcomponents/MainMap/PlantsMenu.vue
@@ -134,13 +134,13 @@ function confirmDeploy() {
   border-radius: 10px;
   background: #e0f7fa;
   padding: 1rem 0.5rem;
-  margin: 0 1rem 0 0;
+  margin: 0 0 0 1rem;
   min-width: 170px;
   max-width: 220px;
   height: 60vh;
   display: flex;
   flex-direction: column;
-  float: right;
+  flex: 0 0 auto;
 }
 .verticalMenuScroll {
   display: flex;
@@ -197,6 +197,9 @@ function confirmDeploy() {
   border-radius: 12px;
   box-shadow: 0 4px 24px #0002;
   min-width: 250px;
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 1em;

--- a/src/components/subcomponents/MainMap/TilesGrid.vue
+++ b/src/components/subcomponents/MainMap/TilesGrid.vue
@@ -370,6 +370,8 @@ function confirmMoveAnimal() {
   padding: 2.1em 2.4em;
   min-width: 290px;
   max-width: 360px;
+  max-height: 90vh;
+  overflow-y: auto;
   font-size: 1.11em;
   line-height: 1.45;
   position: relative;


### PR DESCRIPTION
## Summary
- keep the whole app inside the viewport
- style MarketArea so it fills the screen
- use a flex layout for MainMap
- remove floats from menu components
- constrain modal sizes to viewport

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d47fb9db08327a6b7c279ab1d5a79