### PR TITLE
Implement module attachment validation

### DIFF
--- a/src/components/subcomponents/AssemblyArea/ModulesMenu.vue
+++ b/src/components/subcomponents/AssemblyArea/ModulesMenu.vue
@@ -46,11 +46,35 @@ function sellModule(moduleName) {
   showToast(`Sold ${mod.name} for 💰${refund}`)
 }
 
+// --- Assembly compatibility helpers ---
+function remainingSlots(type) {
+  const hosts = modules.currentAssembly.filter(m => m.type === type)
+  if (!hosts.length) return 0
+  const capacity = hosts.reduce((sum, h) => sum + (h.maxSlots || 0), 0)
+  const used = modules.currentAssembly.filter(m => m.attachesTo.includes(type)).length
+  return capacity - used
+}
+
+function canAttach(mod) {
+  if (!mod.attachesTo || mod.attachesTo.length === 0) return true
+  return mod.attachesTo.some(attType => {
+    const hosts = modules.currentAssembly.filter(m => m.type === attType)
+    if (!hosts.length) return false
+    const hasSlot = hosts.some(h => (h.slots || []).includes(mod.type))
+    if (!hasSlot) return false
+    return remainingSlots(attType) > 0
+  })
+}
+
 
 function addModuleToAssembly(moduleName) {
   const mod = modules.availableModules.find(m => m.name === moduleName)
   if (!mod || (mod.count || 0) <= 0) {
     showToast('You do not have any in stock.')
+    return
+  }
+  if (!canAttach(mod)) {
+    showToast('No compatible slot available.')
     return
   }
   modules.currentAssembly.push({...mod})
@@ -93,6 +117,7 @@ function showToast(msg) {
               <div class="button-group">
                 <button
                     v-if="mod.count > 0"
+                    :disabled="!canAttach(mod)"
                     @click="addModuleToAssembly(mod.name)"
                     class="add-btn"
                 >


### PR DESCRIPTION
## Summary
- enforce module compatibility rules when building assemblies
- disable add button if no compatible slot is available

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a2ef293c08327b10feb7d1f684190