### PR TITLE
Refactor menu layout

### DIFF
--- a/src/components/MainMap.vue
+++ b/src/components/MainMap.vue
@@ -38,11 +38,17 @@ const acceptedOrdersDisplay = computed(() =>
 <template>
   <div class="main-map-wrapper">
     <StatusBar />
-    <AssembliesMenu title="Available Assemblies" />
+    <div class="assemblies-menu-area">
+      <AssembliesMenu title="Available Assemblies" />
+    </div>
     <div class="center-area">
-      <AnimalsMenu />
+      <div class="left-menu">
+        <AnimalsMenu />
+      </div>
       <TilesGrid />
-      <PlantsMenu />
+      <div class="right-menu">
+        <PlantsMenu />
+      </div>
     </div>
     <HarvestedMenu :items="acceptedOrdersDisplay" />
   </div>
@@ -63,4 +69,27 @@ const acceptedOrdersDisplay = computed(() =>
   align-items: flex-start;
   justify-content: center;
   overflow: hidden;
-}</style>
+}
+
+.assemblies-menu-area {
+  flex: 0 0 auto;
+  margin: 0.5rem 0;
+}
+
+.left-menu,
+.right-menu {
+  flex: 0 0 auto;
+  height: 100%;
+  min-width: 170px;
+  max-width: 220px;
+  display: flex;
+}
+
+.left-menu {
+  margin-right: 1rem;
+}
+
+.right-menu {
+  margin-left: 1rem;
+}
+</style>

--- a/src/components/subcomponents/MainMap/AnimalsMenu.vue
+++ b/src/components/subcomponents/MainMap/AnimalsMenu.vue
@@ -252,13 +252,8 @@ function closeRequirementsModal() {
   border-radius: 10px;
   background: #e0f7fa;
   padding: 1rem 0.5rem;
-  margin: 0 1rem 0 0;
-  min-width: 170px;
-  max-width: 220px;
-  height: 60vh;
   display: flex;
   flex-direction: column;
-  flex: 0 0 auto;
 }
 
 .verticalMenuScroll {

--- a/src/components/subcomponents/MainMap/PlantsMenu.vue
+++ b/src/components/subcomponents/MainMap/PlantsMenu.vue
@@ -327,13 +327,8 @@ function confirmDeploy() {
   border-radius: 10px;
   background: #e0f7fa;
   padding: 1rem 0.5rem;
-  margin: 0 0 0 1rem;
-  min-width: 170px;
-  max-width: 220px;
-  height: 60vh;
   display: flex;
   flex-direction: column;
-  flex: 0 0 auto;
 }
 .verticalMenuScroll {
   display: flex;


### PR DESCRIPTION
## Summary
- centralize external layout rules in `MainMap.vue`
- keep internal styles in each menu component

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d3ef33c788327a556a0d953651014