### PR TITLE
Add news ticker and price modifiers

### DIFF
--- a/stores/gameStateStore.js
+++ b/stores/gameStateStore.js
@@ -8,6 +8,31 @@ export const gameStateStore = defineStore('gameState', () => {
     const temperature = ref(25)       // Celsius
     const rainfall = ref(0)           // mm
     const cloudCover = ref(0.1)       // 0 (clear) to 1 (overcast)
+    const newsFeed = ref([
+        {
+            id: 'news-1',
+            type: 'market',
+            headline: 'Tomato prices soar',
+            details: 'A blight has reduced tomato harvests across the land.',
+            day: 0,
+            effect: { affectedTypes: ['Tomato'], priceModifier: 1.5 }
+        },
+        {
+            id: 'news-2',
+            type: 'weather',
+            headline: 'Heavy rains incoming',
+            details: 'Expect increased rainfall over the next few days.',
+            day: 0
+        },
+        {
+            id: 'news-3',
+            type: 'market',
+            headline: 'Demand for wool drops',
+            details: 'Warm weather lowers demand for wool products.',
+            day: 1,
+            effect: { affectedTypes: ['Wool'], priceModifier: 0.8 }
+        }
+    ])
 
     return {
         startDate,
@@ -15,5 +40,6 @@ export const gameStateStore = defineStore('gameState', () => {
         temperature,
         rainfall,
         cloudCover,
+        newsFeed,
     }
 })


### PR DESCRIPTION
## Summary
- expand `gameStateStore` with `newsFeed`
- show a news ticker in the Market area
- allow going back to the map from the Market area
- adjust contract and offer payouts based on active news

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e4c8f6444832785a7ce89849e56d9