### PR TITLE
Expand tile grid width

### DIFF
--- a/src/components/subcomponents/MainMap/TilesGrid.vue
+++ b/src/components/subcomponents/MainMap/TilesGrid.vue
@@ -927,11 +927,11 @@ function closeAssemblySelectModal() {
 <style scoped>
 .fieldsGrid {
   display: grid;
-  grid-template-columns: repeat(6, 50px);
+  grid-template-columns: repeat(6, 1fr);
   grid-template-rows: repeat(6, 50px);
   gap: 8px;
   margin: 2em auto;
-  max-width: 340px;
+  width: 100%;
   background: #c8e6c9;
   padding: 1em;
   border-radius: 15px;


### PR DESCRIPTION
## Summary
- stretch the tile grid to fill the available width so each tile can use all horizontal space

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687fc2b37f20832780c124757b81976c