### PR TITLE
Centralize shared styles

### DIFF
--- a/src/components/AssemblyArea.vue
+++ b/src/components/AssemblyArea.vue
@@ -32,11 +32,11 @@ function handlePremadeSelect(assembly) {
   <div class="assembly-area-main">
     <!-- Top bar with left, center, right -->
     <div class="top-bar">
-      <button @click="openNewAssemblyModal" class="new-btn">+ New Assembly</button>
+      <button @click="openNewAssemblyModal" class="btn btn--new">+ New Assembly</button>
       <div class="assemblies-bar">
         <ActiveAssemblyMenu/>
       </div>
-      <button class="return-btn" @click="eventBus.emit('nav', 'main')">
+      <button class="btn btn--return" @click="eventBus.emit('nav', 'main')">
         Return to Map
       </button>
     </div>
@@ -77,19 +77,7 @@ function handlePremadeSelect(assembly) {
   gap: 1.1em;
 }
 
-.new-btn {
-  padding: 0.35em 1.2em;
-  border-radius: 7px;
-  background: #ffd600;
-  border: none;
-  font-weight: bold;
-  cursor: pointer;
-  margin-right: 0.8em;
-}
-.new-btn:hover {
-  background: #ffb300;
-  color: #333;
-}
+
 
 .assemblies-bar {
   flex: 1 1 auto;
@@ -97,22 +85,7 @@ function handlePremadeSelect(assembly) {
   align-items: center;
 }
 
-.return-btn {
-  margin-left: auto;
-  font-weight: bold;
-  padding: 0.39em 1.1em;
-  background: #80deea;
-  color: #2c2c2c;
-  border-radius: 8px;
-  border: none;
-  cursor: pointer;
-  font-size: 1.07em;
-  box-shadow: 0 2px 4px #0001;
-}
-.return-btn:hover {
-  background: #00bcd4;
-  color: #fff;
-}
+
 
 .workspace-row {
   flex: 1 1 auto;

--- a/src/components/MarketArea.vue
+++ b/src/components/MarketArea.vue
@@ -232,7 +232,7 @@ function canSell(o) {
       </div>
       <div v-else class="ticker-inner">No news today.</div>
     </div>
-    <button class="return-btn" @click="eventBus.emit('nav', 'main')">Back to Map</button>
+    <button class="btn btn--return return-btn" @click="eventBus.emit('nav', 'main')">Back to Map</button>
     <h1>Market</h1>
     <div class="filter-row">
       <label>Filter:</label>
@@ -382,16 +382,7 @@ function canSell(o) {
 .return-btn {
   align-self: flex-end;
   margin-bottom: 0.5rem;
-  font-weight: bold;
   padding: 0.4em 1em;
-  background: #80deea;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-}
-.return-btn:hover {
-  background: #26c6da;
-  color: #fff;
 }
 
 @keyframes scroll {

--- a/src/components/StartingScreen.vue
+++ b/src/components/StartingScreen.vue
@@ -71,7 +71,7 @@ function startGame() {
       </div>
     </div>
 
-    <button type="submit">Start</button>
+    <button type="submit" class="btn start-btn">Start</button>
   </form>
 </template>
 
@@ -90,18 +90,14 @@ function startGame() {
   display: flex;
   gap: 1.2rem;
 }
-button[type="submit"] {
+.start-btn {
   margin-top: 1rem;
-  font-weight: bold;
   font-size: 1.1em;
   padding: 0.5em 1.2em;
-  border-radius: 8px;
-  border: none;
   background: #82c91e;
   color: #fff;
-  cursor: pointer;
 }
-button[type="submit"]:hover {
+.start-btn:hover {
   background: #5c940d;
 }
 </style>

--- a/src/components/subcomponents/AssemblyArea/AssemblyWorkspace.vue
+++ b/src/components/subcomponents/AssemblyArea/AssemblyWorkspace.vue
@@ -50,12 +50,12 @@ function returnAllToPool() {
     <ul class="current-modules-list">
       <li v-for="(mod, i) in modules.currentAssembly" :key="mod.name + i">
         <span>{{ mod.name }} — type: {{ mod.type }}</span>
-        <button class="return-btn" @click="returnToPool(i)">return to module pool</button>
+        <button class="btn btn--return return-btn" @click="returnToPool(i)">return to module pool</button>
       </li>
       <li v-if="!modules.currentAssembly.length" class="empty-msg">No modules added yet.</li>
     </ul>
     <button
-        class="return-all-btn"
+        class="btn btn--return return-all-btn"
         :disabled="!modules.currentAssembly.length"
         @click="returnAllToPool"
     >
@@ -63,7 +63,7 @@ function returnAllToPool() {
     </button>
     <hr/>
     <button
-        class="save-btn"
+        class="btn btn--save save-btn"
         :disabled="!modules.currentAssembly.length"
         @click="saveAssembly"
     >Save Assembly</button>
@@ -108,43 +108,13 @@ function returnAllToPool() {
   font-style: italic;
 }
 .save-btn {
-  background: #ffd600;
-  color: #333;
-  border: none;
-  border-radius: 8px;
-  font-weight: bold;
-  font-size: 1em;
-  padding: 0.58em 1.8em;
-  cursor: pointer;
   margin-top: 0.6em;
-}
-.save-btn:disabled {
-  background: #eee;
-  color: #aaa;
-  cursor: not-allowed;
-}
-.save-btn:not(:disabled):hover {
-  background: #ffb300;
+  padding: 0.58em 1.8em;
 }
 
 .return-all-btn {
-  background: #e0f7fa;
-  color: #0097a7;
-  border: none;
-  border-radius: 8px;
-  font-size: 1em;
-  font-weight: 500;
-  padding: 0.45em 1.3em;
   margin-top: 0.3em;
   margin-left: 0.9em;
-  cursor: pointer;
-}
-.return-all-btn:disabled {
-  background: #eee;
-  color: #aaa;
-  cursor: not-allowed;
-}
-.return-all-btn:not(:disabled):hover {
-  background: #b2ebf2;
+  padding: 0.45em 1.3em;
 }
 </style>

--- a/src/components/subcomponents/AssemblyArea/ModulesMenu.vue
+++ b/src/components/subcomponents/AssemblyArea/ModulesMenu.vue
@@ -127,21 +127,21 @@ function showToast(msg) {
                     :title="!canAttach(mod) ? attachTooltip(mod) : ''"
 
                     @click="addModuleToAssembly(mod.name)"
-                    class="add-btn"
+                    class="btn btn--add add-btn"
                 >
                   + Add
                 </button>
                 <button
                     @click="buyModule(mod.name)"
                     :disabled="gameState.gold < mod.cost"
-                    class="buy-btn"
+                    class="btn btn--buy buy-btn"
                 >
                   Buy
                 </button>
                 <button
                     v-if="mod.count > 0"
                     @click="sellModule(mod.name)"
-                    class="sell-btn"
+                    class="btn btn--sell sell-btn"
                     title="Sell for half price"
                 >
                   Sell
@@ -245,45 +245,11 @@ h2 {
 }
 
 .buy-btn {
-  background: #ffd600;
-  border: none;
-  border-radius: 7px;
   padding: 0.23em 0.85em;
-  font-weight: bold;
-  cursor: pointer;
-}
-
-.buy-btn:disabled {
-  background: #eee;
-  color: #aaa;
-  cursor: not-allowed;
-}
-
-.buy-btn:not(:disabled):hover {
-  background: #ffb300;
-  color: #fff;
 }
 
 .sell-btn {
-  background: #e0e0e0;
-  border: none;
-  border-radius: 7px;
   padding: 0.23em 0.85em;
-  font-weight: bold;
-  cursor: pointer;
-  color: #37474f;
-  transition: background 0.15s;
-}
-
-.sell-btn:disabled {
-  background: #eee;
-  color: #aaa;
-  cursor: not-allowed;
-}
-
-.sell-btn:not(:disabled):hover {
-  background: #cfd8dc;
-  color: #263238;
 }
 
 
@@ -337,25 +303,7 @@ h2 {
 }
 
 .add-btn {
-  background: #c8e6c9;
-  border: none;
-  border-radius: 7px;
   padding: 0.23em 0.85em;
-  font-weight: bold;
-  cursor: pointer;
-  color: #388e3c;
-  transition: background 0.15s;
-}
-
-.add-btn:disabled {
-  background: #eee;
-  color: #aaa;
-  cursor: not-allowed;
-}
-
-.add-btn:not(:disabled):hover {
-  background: #a5d6a7;
-  color: #1b5e20;
 }
 
 .module-row {

--- a/src/components/subcomponents/AssemblyArea/PremadeAssembliesMenu.vue
+++ b/src/components/subcomponents/AssemblyArea/PremadeAssembliesMenu.vue
@@ -116,7 +116,7 @@ function close() {
 
 
       </div>
-      <button class="close-btn" @click="close">Cancel</button>
+      <button class="btn btn--close close-btn" @click="close">Cancel</button>
     </div>
   </div>
 </template>
@@ -224,17 +224,6 @@ h2 {
 .close-btn {
   margin-top: 1.5em;
   padding: 0.39em 1.7em;
-  background: #ffd600;
-  border: none;
-  border-radius: 8px;
-  font-weight: bold;
-  font-size: 1em;
-  cursor: pointer;
-}
-
-.close-btn:hover {
-  background: #ffb300;
-  color: #222;
 }
 
 .assembly-card.blank {

--- a/src/components/subcomponents/MainMap/AnimalsMenu.vue
+++ b/src/components/subcomponents/MainMap/AnimalsMenu.vue
@@ -35,18 +35,18 @@ function buy(animal) {
 </script>
 
 <template>
-  <div class="verticalMenuArea">
-    <div class="verticalMenuScroll">
+  <div class="menu-panel">
+    <div class="scroll-area">
       <template v-if="mode === 'normal'">
         <div
             v-for="animal in animals.animalTypes"
             :key="animal.type"
-            class="verticalMenuCard"
+            class="card card--horizontal"
         >
           <span class="verticalMenu-icon">{{ animal.icon }}</span>
           <span class="verticalMenu-type">{{ animal.type }}</span>
           <span class="verticalMenu-cost">{{ animal.cost }}💰</span>
-          <button class="buyBtn" :disabled="gameState.gold < animal.cost" @click="buy(animal)">
+          <button class="btn btn--buy" :disabled="gameState.gold < animal.cost" @click="buy(animal)">
             Buy
           </button>
         </div>
@@ -70,32 +70,11 @@ function buy(animal) {
 
 
 <style scoped>
-.verticalMenuArea {
-  border: 2px solid #b2dfdb;
-  border-radius: 10px;
-  background: #e0f7fa;
-  padding: 1rem 0.5rem;
-  display: flex;
-  flex-direction: column;
-}
-
-.verticalMenuScroll {
-  display: flex;
-  flex-direction: column;
-  gap: 1em;
-  overflow-y: auto;
-  flex: 1 1 auto;
-  padding-right: 0.5em;
-}
-
 .verticalMenuCard {
   display: flex;
   flex-direction: row;
   align-items: center;
   gap: 0.8em;
-  background: #fff;
-  border-radius: 7px;
-  box-shadow: 0 1px 4px #0001;
   padding: 0.4em 0.8em;
   min-height: 45px;
 }
@@ -112,24 +91,6 @@ function buy(animal) {
 .buyBtn {
   margin-left: auto;
   padding: 0.2em 1em;
-  border-radius: 7px;
-  background: #b2dfdb;
-  border: none;
-  color: #333;
-  font-weight: bold;
-  cursor: pointer;
-}
-
-.buyBtn:hover {
-  background: #00bcd4;
-  color: #fff;
-}
-
-.buyBtn:disabled {
-  background: #ddd !important;
-  color: #888 !important;
-  cursor: not-allowed !important;
-  border: 1px solid #bbb;
 }
 .feedback-msg {
   color: #388e3c;

--- a/src/components/subcomponents/MainMap/AssembliesMenu.vue
+++ b/src/components/subcomponents/MainMap/AssembliesMenu.vue
@@ -106,7 +106,7 @@ function confirmDeploy() {
             {{ assembly.name || 'Assembly' }}
           </span>
           <button
-              class="buyBtn"
+              class="btn btn--buy buyBtn"
               @click="openDeployModal(assembly.id)"
           >
             Deploy
@@ -259,25 +259,8 @@ function confirmDeploy() {
 .buyBtn {
   margin-top: 0.2em;
   padding: 0.21em 1em;
-  border-radius: 7px;
-  background: #b2dfdb;
-  border: none;
-  color: #333;
-  font-weight: bold;
-  cursor: pointer;
-  font-size: 1em;
   position: absolute;
   bottom: 5px;
-}
-.buyBtn:hover {
-  background: #00bcd4;
-  color: #fff;
-}
-.buyBtn:disabled {
-  background: #ddd !important;
-  color: #888 !important;
-  cursor: not-allowed !important;
-  border: 1px solid #bbb;
 }
 .empty {
   color: #888;

--- a/src/components/subcomponents/MainMap/Modals/GateModal.vue
+++ b/src/components/subcomponents/MainMap/Modals/GateModal.vue
@@ -2,7 +2,7 @@
   <div class="areaModal" @click.self="$emit('close')">
     <div class="gate-modal-content">
       <h1>Farm Gate</h1>
-      <button class="close-btn" @click="$emit('close')">×</button>
+      <button class="btn btn--close close-btn" @click="$emit('close')">×</button>
       <div class="subject-header">
         <span class="icon">{{ item.icon }}</span>
         <span class="type">{{ item.type }}</span>
@@ -52,10 +52,7 @@ defineProps({
 .close-btn {
   position: absolute; top: 1.1em; right: 1.15em;
   font-size: 1.4em;
-  background: none; border: none; cursor: pointer;
-  color: #aaa; font-weight: bold;
 }
-.close-btn:hover { color: #222; }
 .subject-header {
   display: flex; gap: 0.8em; align-items: center; font-size: 1.15em;
 }

--- a/src/components/subcomponents/MainMap/Modals/TileModal.vue
+++ b/src/components/subcomponents/MainMap/Modals/TileModal.vue
@@ -103,7 +103,7 @@ const tileEffects = computed(() => {
 <template>
   <div class="areaModal" @click.self="$emit('close')">
     <div class="tile-modal-content">
-      <button class="close-btn" @click="$emit('close')">×</button>
+      <button class="btn btn--close close-btn" @click="$emit('close')">×</button>
       <h2>
         Tile ({{ tile.row + 1 }}, {{ tile.col + 1 }})
       </h2>
@@ -215,15 +215,6 @@ const tileEffects = computed(() => {
   top: 1.1em;
   right: 1.15em;
   font-size: 1.4em;
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: #aaa;
-  font-weight: bold;
-}
-
-.close-btn:hover {
-  color: #222;
 }
 
 .tile-soil {

--- a/src/components/subcomponents/MainMap/PlantsMenu.vue
+++ b/src/components/subcomponents/MainMap/PlantsMenu.vue
@@ -52,22 +52,22 @@ function buy(plant, plantingType) {
 </script>
 
 <template>
-  <div class="verticalMenuArea">
-    <div class="verticalMenuScroll">
+  <div class="menu-panel">
+    <div class="scroll-area">
       <template v-if="mode === 'normal'">
         <template v-for="category in ['annuals', 'perennials']" :key="category">
           <div
               v-for="plant in plants.plantTypes[category]"
               :key="plant.type"
-              class="verticalMenuCard"
+              class="card card--vertical"
           >
             <span class="verticalMenu-icon">{{ plant.icon }}</span>
             <span class="verticalMenu-type">{{ plant.type }}</span>
             <div class="deploy-buttons">
-              <button class="buyBtn" @click="buy(plant, 'seed')">
+              <button class="btn btn--buy" @click="buy(plant, 'seed')">
                 Seed: {{ plant.seedCost }}💰
               </button>
-              <button class="buyBtn" @click="buy(plant, 'seedling')">
+              <button class="btn btn--buy" @click="buy(plant, 'seedling')">
                 Seedling: {{ plant.seedlingCost }}💰
               </button>
             </div>
@@ -92,30 +92,11 @@ function buy(plant, plantingType) {
 
 
 <style scoped>
-.verticalMenuArea {
-  border: 2px solid #b2dfdb;
-  border-radius: 10px;
-  background: #e0f7fa;
-  padding: 1rem 0.5rem;
-  display: flex;
-  flex-direction: column;
-}
-.verticalMenuScroll {
-  display: flex;
-  flex-direction: column;
-  gap: 1em;
-  overflow-y: auto;
-  flex: 1 1 auto;
-  padding-right: 0.5em;
-}
 .verticalMenuCard {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 0.5em;
-  background: #fff;
-  border-radius: 7px;
-  box-shadow: 0 1px 4px #0001;
   padding: 0.7em 0.8em 0.8em 0.8em;
   min-height: 125px;
   position: relative;
@@ -135,22 +116,5 @@ function buy(plant, plantingType) {
   width: 100%;
   align-items: stretch;
   margin-top: 0.7em;
-}
-.buyBtn {
-
-  padding: 0.45em 0.6em;
-  border-radius: 7px;
-  background: #b2dfdb;
-  border: none;
-  color: #222;
-  font-weight: bold;
-  cursor: pointer;
-  font-size: 1em;
-  transition: background 0.14s;
-  flex:1;
-}
-.buyBtn:hover {
-  background: #00bcd4;
-  color: #fff;
 }
 </style>

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import { createApp } from 'vue'
 import {createPinia} from 'pinia'
 import App from './App.vue'
+import './styles/universal.css'
 
 
 const app = createApp(App)

--- a/src/styles/universal.css
+++ b/src/styles/universal.css
@@ -1,0 +1,142 @@
+:root {
+  --color-primary: #00bcd4;
+  --color-accent: #b2dfdb;
+  --color-warning: #ffd600;
+  --color-dark: #333;
+  --radius: 7px;
+}
+
+.menu-panel {
+  border: 2px solid var(--color-accent);
+  border-radius: 10px;
+  background: #e0f7fa;
+  padding: 1rem 0.5rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.scroll-area {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  padding-right: 0.5em;
+}
+
+.card {
+  background: #fff;
+  border-radius: var(--radius);
+  box-shadow: 0 1px 4px #0001;
+  padding: 0.7em 0.8em;
+  display: flex;
+  flex-direction: column;
+}
+
+.card--horizontal {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.8em;
+  padding: 0.4em 0.8em;
+}
+
+.card--vertical {
+  align-items: center;
+  gap: 0.5em;
+  justify-content: space-between;
+}
+
+.btn {
+  border: none;
+  border-radius: var(--radius);
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.btn--buy {
+  background: var(--color-accent);
+  color: var(--color-dark);
+}
+.btn--buy:hover {
+  background: var(--color-primary);
+  color: #fff;
+}
+.btn--buy:disabled {
+  background: #ddd;
+  color: #888;
+  cursor: not-allowed;
+  border: 1px solid #bbb;
+}
+
+.btn--return {
+  background: #80deea;
+  color: #2c2c2c;
+  padding: 0.39em 1.1em;
+  box-shadow: 0 2px 4px #0001;
+}
+.btn--return:hover {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.btn--new {
+  background: var(--color-warning);
+  margin-right: 0.8em;
+  padding: 0.35em 1.2em;
+}
+.btn--new:hover {
+  background: #ffb300;
+  color: #333;
+}
+
+.btn--close {
+  background: none;
+  color: #aaa;
+}
+.btn--close:hover {
+  color: #222;
+}
+
+.btn--save {
+  background: var(--color-warning);
+  color: var(--color-dark);
+  padding: 0.58em 1.8em;
+}
+.btn--save:hover {
+  background: #ffb300;
+}
+.btn--save:disabled {
+  background: #eee;
+  color: #aaa;
+  cursor: not-allowed;
+}
+
+.btn--add {
+  background: #c8e6c9;
+  color: #388e3c;
+  padding: 0.23em 0.85em;
+}
+.btn--add:hover {
+  background: #a5d6a7;
+  color: #1b5e20;
+}
+.btn--add:disabled {
+  background: #eee;
+  color: #aaa;
+  cursor: not-allowed;
+}
+
+.btn--sell {
+  background: #e0e0e0;
+  color: #37474f;
+  padding: 0.23em 0.85em;
+}
+.btn--sell:hover {
+  background: #cfd8dc;
+  color: #263238;
+}
+.btn--sell:disabled {
+  background: #eee;
+  color: #aaa;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary
- extract repeated button, card, and panel styles into `src/styles/universal.css`
- import the global stylesheet in `main.js`
- update menu components to use new class names
- remove redundant scoped CSS in components

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68895ed32d088327a0f3b25f12774388