### PR TITLE
Organize Vue scripts

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,11 @@
 <script setup>
-import { ref, onMounted, onBeforeUnmount } from 'vue'
-import StartingScreen from '@/components/StartingScreen.vue'
-import MainMap from '@/components/MainMap.vue'
 import AssemblyArea from '@/components/AssemblyArea.vue'
-import MarketArea from "@/components/MarketArea.vue";
-import { gameStateStore } from '/stores/gameStateStore.js'
 import eventBus from '@/eventBus.js'
+import { gameStateStore } from '/stores/gameStateStore.js'
+import MainMap from '@/components/MainMap.vue'
+import MarketArea from '@/components/MarketArea.vue'
+import StartingScreen from '@/components/StartingScreen.vue'
+import { onBeforeUnmount, onMounted, ref } from 'vue'
 
 const gameState = gameStateStore()
 const currentScreen = ref(

--- a/src/components/AssemblyArea.vue
+++ b/src/components/AssemblyArea.vue
@@ -1,11 +1,11 @@
 <script setup>
-import { ref } from 'vue'
-import eventBus from "@/eventBus.js";
+import ActiveAssemblyMenu from '@/components/subcomponents/assemblyArea/ActiveAssemblyMenu.vue'
+import AssemblyWorkspace from '@/components/subcomponents/assemblyArea/AssemblyWorkspace.vue'
+import eventBus from '@/eventBus.js'
 import ModulesMenu from '@/components/subcomponents/assemblyArea/ModulesMenu.vue'
-import ActiveAssemblyMenu from "@/components/subcomponents/assemblyArea/ActiveAssemblyMenu.vue";
-import PremadeAssembliesMenu from "@/components/subcomponents/assemblyArea/PremadeAssembliesMenu.vue"
-import AssemblyWorkspace from "@/components/subcomponents/assemblyArea/AssemblyWorkspace.vue";
+import PremadeAssembliesMenu from '@/components/subcomponents/assemblyArea/PremadeAssembliesMenu.vue'
 import { modulesStore } from '/stores/modulesStore.js'
+import { ref } from 'vue'
 
 const showPremadeModal = ref(false)
 const modules = modulesStore()

--- a/src/components/MainMap.vue
+++ b/src/components/MainMap.vue
@@ -1,11 +1,11 @@
 <script setup>
 
-import StatusBar from '@/components/subcomponents/mainMap/StatusBar.vue';
-import AssembliesMenu from "@/components/subcomponents/mainMap/AssembliesMenu.vue";
-import HarvestedMenu from "@/components/subcomponents/mainMap/HarvestedMenu.vue";
-import PlantsMenu from "@/components/subcomponents/mainMap/PlantsMenu.vue";
-import AnimalsMenu from "@/components/subcomponents/mainMap/AnimalsMenu.vue";
-import TilesGrid from "@/components/subcomponents/mainMap/TilesGrid.vue";
+import AnimalsMenu from '@/components/subcomponents/mainMap/AnimalsMenu.vue'
+import AssembliesMenu from '@/components/subcomponents/mainMap/AssembliesMenu.vue'
+import HarvestedMenu from '@/components/subcomponents/mainMap/HarvestedMenu.vue'
+import PlantsMenu from '@/components/subcomponents/mainMap/PlantsMenu.vue'
+import StatusBar from '@/components/subcomponents/mainMap/StatusBar.vue'
+import TilesGrid from '@/components/subcomponents/mainMap/TilesGrid.vue'
 </script>
 
 <template>

--- a/src/components/MarketArea.vue
+++ b/src/components/MarketArea.vue
@@ -1,11 +1,11 @@
 <script setup>
-import { computed, onMounted, ref } from 'vue'
-import { v4 as uuidv4 } from 'uuid'
-import { marketStore } from '/stores/marketStore.js'
-import { animalsStore } from '/stores/animalsStore.js'
-import { plantsStore } from '/stores/plantsStore.js'
-import { gameStateStore } from '/stores/gameStateStore.js'
 import eventBus from '@/eventBus.js'
+import { animalsStore } from '/stores/animalsStore.js'
+import { gameStateStore } from '/stores/gameStateStore.js'
+import { marketStore } from '/stores/marketStore.js'
+import { plantsStore } from '/stores/plantsStore.js'
+import { v4 as uuidv4 } from 'uuid'
+import { computed, onMounted, ref } from 'vue'
 
 const market = marketStore()
 

--- a/src/components/StartingScreen.vue
+++ b/src/components/StartingScreen.vue
@@ -1,9 +1,10 @@
 <script setup>
-import { ref } from 'vue'
+import eventBus from '@/eventBus.js'
 import { gameStateStore } from '/stores/gameStateStore.js'
+import { ref } from 'vue'
+
 const gameState = gameStateStore()
 const name = ref('')
-import eventBus from "@/eventBus.js";
 
 const avatarOptions = [
   { emoji: '😀', label: 'Smiling Face' },

--- a/src/components/subcomponents/assemblyArea/ActiveAssemblyMenu.vue
+++ b/src/components/subcomponents/assemblyArea/ActiveAssemblyMenu.vue
@@ -1,6 +1,6 @@
 <script setup>
-import { computed } from 'vue'
 import { modulesStore } from '/stores/modulesStore.js'
+import { computed } from 'vue'
 
 const modules = modulesStore()
 

--- a/src/components/subcomponents/assemblyArea/AssemblyWorkspace.vue
+++ b/src/components/subcomponents/assemblyArea/AssemblyWorkspace.vue
@@ -1,7 +1,7 @@
 <script setup>
-import { ref } from 'vue'
 import { modulesStore } from '/stores/modulesStore.js'
 import { v4 as uuidv4 } from 'uuid'
+import { ref } from 'vue'
 
 const modules = modulesStore()
 const name = ref('')

--- a/src/components/subcomponents/assemblyArea/ModulesMenu.vue
+++ b/src/components/subcomponents/assemblyArea/ModulesMenu.vue
@@ -1,7 +1,7 @@
 <script setup>
-import {ref, computed} from 'vue'
 import {modulesStore} from '/stores/modulesStore.js'
 import {gameStateStore} from '/stores/gameStateStore.js'
+import {computed, ref} from 'vue'
 
 const modules = modulesStore()
 const gameState = gameStateStore()

--- a/src/components/subcomponents/assemblyArea/PremadeAssembliesMenu.vue
+++ b/src/components/subcomponents/assemblyArea/PremadeAssembliesMenu.vue
@@ -1,7 +1,7 @@
 <script setup>
 
-import { modulesStore } from '/stores/modulesStore.js'
 import { gameStateStore } from '/stores/gameStateStore.js'
+import { modulesStore } from '/stores/modulesStore.js'
 
 const emit = defineEmits(['close'])
 

--- a/src/components/subcomponents/mainMap/AnimalsMenu.vue
+++ b/src/components/subcomponents/mainMap/AnimalsMenu.vue
@@ -1,12 +1,12 @@
 <script setup>
-import {animalsStore} from '/stores/animalsStore.js'
-import {tilesStore} from '/stores/tilesStore.js'
-import {gameStateStore} from "../../../../stores/gameStateStore.js";
-import {computed, onBeforeUnmount, onMounted, ref} from "vue";
-import eventBus from "@/eventBus.js";
+import eventBus from '@/eventBus.js'
+import HarvestProduct from '@/components/subcomponents/mainMap/actions/animals/HarvestAnimalProduct.vue'
 import MoveAnimal from '@/components/subcomponents/mainMap/actions/animals/Move.vue'
-import SetCollar from '@/components/subcomponents/mainMap/actions/animals/SetCollar.vue';
-import HarvestProduct from "@/components/subcomponents/mainMap/actions/animals/HarvestAnimalProduct.vue";
+import SetCollar from '@/components/subcomponents/mainMap/actions/animals/SetCollar.vue'
+import { animalsStore } from '/stores/animalsStore.js'
+import { gameStateStore } from "../../../../stores/gameStateStore.js"
+import { tilesStore } from '/stores/tilesStore.js'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 
 const animals = animalsStore()
 const tiles = tilesStore()
@@ -14,24 +14,27 @@ const gameState = gameStateStore();
 
 const isGate = computed(() => !tiles.selectedSubject.value.hasOwnProperty('row'))
 const mode = ref('normal')
-const feedbackMsg = ref([]);
-function setFeedbackMsg(msg) { feedbackMsg.value.push(msg); }
-onMounted(() => {
-  eventBus.on('menus-mode', changeMode)
-})
-onBeforeUnmount(() => {
-  eventBus.off('menus-mode', changeMode)
-})
+const feedbackMsg = ref([])
 
-function changeMode(e) {
-  mode.value = e;
-  feedbackMsg.value =[];
-}
+function setFeedbackMsg(msg) { feedbackMsg.value.push(msg) }
 
 function buy(animal) {
   tiles.gate.animals.push({...animal, dateDeployed: gameState.day})
   gameState.gold -= animal.cost
 }
+
+function changeMode(e) {
+  mode.value = e
+  feedbackMsg.value = []
+}
+
+onMounted(() => {
+  eventBus.on('menus-mode', changeMode)
+})
+
+onBeforeUnmount(() => {
+  eventBus.off('menus-mode', changeMode)
+})
 </script>
 
 <template>

--- a/src/components/subcomponents/mainMap/HarvestedMenu.vue
+++ b/src/components/subcomponents/mainMap/HarvestedMenu.vue
@@ -1,10 +1,6 @@
 <script setup>
-import {computed, ref} from "vue";
-
-
-
-
 import { marketStore } from '/stores/marketStore.js'
+import { computed, ref } from 'vue'
 const market = marketStore()
 const harvested = computed(() => market.harvestedProducts)
 </script>

--- a/src/components/subcomponents/mainMap/PlantsMenu.vue
+++ b/src/components/subcomponents/mainMap/PlantsMenu.vue
@@ -1,12 +1,11 @@
 <script setup>
-import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import eventBus from '@/eventBus.js'
+import HarvestPlant from '@/components/subcomponents/mainMap/actions/plants/HarvestPlantProduct.vue'
+import SowPlant from '@/components/subcomponents/mainMap/actions/plants/Sow.vue'
+import { gameStateStore } from '/stores/gameStateStore.js'
 import { plantsStore } from '/stores/plantsStore.js'
 import { tilesStore } from '/stores/tilesStore.js'
-import { gameStateStore } from '/stores/gameStateStore.js'
-import eventBus from '@/eventBus.js'
-
-import SowPlant from '@/components/subcomponents/mainMap/actions/plants/Sow.vue'
-import HarvestPlant from '@/components/subcomponents/mainMap/actions/plants/HarvestPlantProduct.vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 
 const plants = plantsStore()
 const tiles = tilesStore()
@@ -25,14 +24,6 @@ function changeMode(e) {
   feedbackMsg.value = []
 }
 
-onMounted(() => {
-  eventBus.on('menus-mode', changeMode)
-})
-
-onBeforeUnmount(() => {
-  eventBus.off('menus-mode', changeMode)
-})
-
 function buy(plant, plantingType) {
   const cost = plantingType === 'seed' ? plant.seedCost : plant.seedlingCost
 
@@ -49,6 +40,14 @@ function buy(plant, plantingType) {
   })
   gameState.gold -= cost
 }
+
+onMounted(() => {
+  eventBus.on('menus-mode', changeMode)
+})
+
+onBeforeUnmount(() => {
+  eventBus.off('menus-mode', changeMode)
+})
 </script>
 
 <template>

--- a/src/components/subcomponents/mainMap/StatusBar.vue
+++ b/src/components/subcomponents/mainMap/StatusBar.vue
@@ -1,9 +1,9 @@
 <script setup>
-import {computed, ref} from 'vue'
-import {gameStateStore} from '/stores/gameStateStore.js'
+import eventBus from '@/eventBus.js'
+import { gameStateStore } from '/stores/gameStateStore.js'
+import { computed, ref } from 'vue'
 // Store instances
 const gameState = gameStateStore()
-import eventBus from "@/eventBus.js";
 
 
 // Real date for day 1

--- a/src/components/subcomponents/mainMap/TilesGrid.vue
+++ b/src/components/subcomponents/mainMap/TilesGrid.vue
@@ -1,9 +1,9 @@
 <script setup>
-import {ref, computed} from 'vue'
-import {tilesStore} from '/stores/tilesStore.js'
+import eventBus from '@/eventBus.js'
 import GateModal from '@/components/subcomponents/mainMap/modals/GateModal.vue'
 import TileModal from '@/components/subcomponents/mainMap/modals/TileModal.vue'
-import eventBus from "@/eventBus.js";
+import { tilesStore } from '/stores/tilesStore.js'
+import { computed, ref } from 'vue'
 
 const tilesStoreInstance = tilesStore()
 const tiles = tilesStoreInstance.tiles

--- a/src/components/subcomponents/mainMap/actions/animals/HarvestAnimalProduct.vue
+++ b/src/components/subcomponents/mainMap/actions/animals/HarvestAnimalProduct.vue
@@ -1,12 +1,12 @@
 <script setup>
-import {ref, computed} from 'vue'
-import {gameStateStore} from '/stores/gameStateStore.js'
+import ModuleRequirementsTable from '@/components/subcomponents/mainMap/actions/ModuleRequirementsTable.vue'
 import {animalsStore} from '/stores/animalsStore.js'
-import {assemblyMeetsRequirements, getMatchingModuleNames, getRequirements} from '@/rules/utils.js'
-import {tilesStore} from "/stores/tilesStore.js";
-import {marketStore} from "/stores/marketStore.js";
+import {gameStateStore} from '/stores/gameStateStore.js'
+import {marketStore} from '/stores/marketStore.js'
 import {modulesStore} from '/stores/modulesStore.js'
-import ModuleRequirementsTable from "@/components/subcomponents/mainMap/actions/ModuleRequirementsTable.vue";
+import {tilesStore} from '/stores/tilesStore.js'
+import {assemblyMeetsRequirements, getMatchingModuleNames, getRequirements} from '@/rules/utils.js'
+import {computed, ref} from 'vue'
 
 
 const tiles = tilesStore();

--- a/src/components/subcomponents/mainMap/actions/animals/Move.vue
+++ b/src/components/subcomponents/mainMap/actions/animals/Move.vue
@@ -1,9 +1,9 @@
 <script setup>
-import {ref, computed} from 'vue'
+import {assemblyMeetsRequirements, getRequirements, getMatchingModuleNames} from '@/rules/utils.js'
+import ModuleRequirementsTable from '@/components/subcomponents/mainMap/actions/ModuleRequirementsTable.vue'
 import {modulesStore} from '/stores/modulesStore.js'
 import {tilesStore} from '/stores/tilesStore.js'
-import {assemblyMeetsRequirements, getRequirements, getMatchingModuleNames} from '@/rules/utils.js'
-import ModuleRequirementsTable from "@/components/subcomponents/mainMap/actions/ModuleRequirementsTable.vue";
+import {computed, ref} from 'vue'
 
 const props = defineProps({
   isGate: Boolean,

--- a/src/components/subcomponents/mainMap/actions/animals/SetCollar.vue
+++ b/src/components/subcomponents/mainMap/actions/animals/SetCollar.vue
@@ -1,9 +1,9 @@
 <script setup>
-import { ref, computed } from 'vue'
-import { tilesStore } from '/stores/tilesStore.js'
+import ModuleRequirementsTable from '@/components/subcomponents/mainMap/actions/ModuleRequirementsTable.vue'
 import { modulesStore } from '/stores/modulesStore.js'
-import ModuleRequirementsTable from "@/components/subcomponents/mainMap/actions/ModuleRequirementsTable.vue";
-import {assemblyMeetsRequirements, getRequirements, getMatchingModuleNames} from '@/rules/utils.js'
+import { tilesStore } from '/stores/tilesStore.js'
+import { assemblyMeetsRequirements, getRequirements, getMatchingModuleNames } from '@/rules/utils.js'
+import { computed, ref } from 'vue'
 
 
 const tiles = tilesStore()

--- a/src/components/subcomponents/mainMap/actions/assemblies/MoveAndRecall.vue
+++ b/src/components/subcomponents/mainMap/actions/assemblies/MoveAndRecall.vue
@@ -1,7 +1,7 @@
 <script setup>
-import { ref, computed } from 'vue'
 import { modulesStore } from '/stores/modulesStore.js'
-import { tilesStore} from "/stores/tilesStore.js";
+import { tilesStore } from '/stores/tilesStore.js'
+import { computed, ref } from 'vue'
 
 const tilesStoreInstance = tilesStore()
 const allTiles = computed(() => tilesStoreInstance.tiles.flat())

--- a/src/components/subcomponents/mainMap/actions/plants/HarvestPlantProduct.vue
+++ b/src/components/subcomponents/mainMap/actions/plants/HarvestPlantProduct.vue
@@ -1,12 +1,12 @@
 <script setup>
-import { ref, computed } from 'vue'
-import { tilesStore } from '/stores/tilesStore.js'
+import ModuleRequirementsTable from '@/components/subcomponents/mainMap/actions/ModuleRequirementsTable.vue'
+import { gameStateStore } from '/stores/gameStateStore.js'
+import { marketStore } from '/stores/marketStore.js'
 import { modulesStore } from '/stores/modulesStore.js'
 import { plantsStore } from '/stores/plantsStore.js'
-import { marketStore } from '/stores/marketStore.js'
-import { gameStateStore } from '/stores/gameStateStore.js'
+import { tilesStore } from '/stores/tilesStore.js'
 import { assemblyMeetsRequirements, getRequirements, getMatchingModuleNames } from '@/rules/utils.js'
-import ModuleRequirementsTable from "@/components/subcomponents/mainMap/actions/ModuleRequirementsTable.vue";
+import { computed, ref } from 'vue'
 
 
 const props = defineProps({

--- a/src/components/subcomponents/mainMap/actions/plants/Sow.vue
+++ b/src/components/subcomponents/mainMap/actions/plants/Sow.vue
@@ -1,9 +1,9 @@
 <script setup>
-import {ref, computed} from 'vue'
+import ModuleRequirementsTable from '@/components/subcomponents/mainMap/actions/ModuleRequirementsTable.vue'
+import {assemblyMeetsRequirements, getRequirements, getMatchingModuleNames} from '@/rules/utils.js'
 import {modulesStore} from '/stores/modulesStore.js'
 import {tilesStore} from '/stores/tilesStore.js'
-import {assemblyMeetsRequirements, getRequirements, getMatchingModuleNames} from '@/rules/utils.js'
-import ModuleRequirementsTable from "@/components/subcomponents/mainMap/actions/ModuleRequirementsTable.vue";
+import {computed, ref} from 'vue'
 
 const props = defineProps({
   setFeedbackMsg: Function

--- a/src/components/subcomponents/mainMap/modals/TileModal.vue
+++ b/src/components/subcomponents/mainMap/modals/TileModal.vue
@@ -1,10 +1,10 @@
 <script setup>
-import {ref, computed} from 'vue'
-import {effects} from '@/rules/effects.js'
-import {modulesStore} from "/stores/modulesStore.js";
-import {tilesStore} from "/stores/tilesStore.js";
-import {gameStateStore} from "/stores/gameStateStore.js";
-import { getAdjacentTiles } from "@/rules/utils.js";
+import { getAdjacentTiles } from '@/rules/utils.js'
+import { effects } from '@/rules/effects.js'
+import { gameStateStore } from '/stores/gameStateStore.js'
+import { modulesStore } from '/stores/modulesStore.js'
+import { tilesStore } from '/stores/tilesStore.js'
+import { computed, ref } from 'vue'
 
 const modules = modulesStore()
 const tilesStoreInstance = tilesStore()


### PR DESCRIPTION
## Summary
- reorder imports alphabetically across all Vue components
- group variables, functions, and lifecycle hooks in a clearer order
- keep templates and styles intact

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688aba04d488832784ba0bf811262ba1