### PR TITLE
feat: add assembly transport action

### DIFF
--- a/src/components/subcomponents/assemblyArea/AssemblyWorkspace.vue
+++ b/src/components/subcomponents/assemblyArea/AssemblyWorkspace.vue
@@ -2,6 +2,7 @@
 import { modulesStore } from '/stores/modulesStore.js'
 import { v4 as uuidv4 } from 'uuid'
 import { ref } from 'vue'
+import { canAssemblyMoveAlone } from '@/rules/utils.js'
 
 const modules = modulesStore()
 const name = ref('')
@@ -9,11 +10,13 @@ const name = ref('')
 function saveAssembly() {
   if (!modules.currentAssembly.length) return
   const id = uuidv4()
+  const built = canAssemblyMoveAlone({ modules: modules.currentAssembly })
   modules.activeAssemblies.push({
     id,
     name: name.value || id,
     modules: modules.currentAssembly.map(m => ({ ...m })),
     deployed: false,
+    built,
     moves: 1,
     actions: 1
   })

--- a/src/components/subcomponents/mainMap/TilesGrid.vue
+++ b/src/components/subcomponents/mainMap/TilesGrid.vue
@@ -51,7 +51,8 @@ function closeModal() {
               v-for="a in tile.assemblies"
               :key="a.id"
               class="tileAssembly"
-          >{{ a.icon || '🤖' }}</span>
+              :class="{ 'not-built': !a.built }"
+          >{{ a.built ? (a.icon || '🤖') : 'not built yet' }}</span>
         </div>
         <div class="tileStats">
           Tile {{ tile.row + 1 }} , {{ tile.col + 1 }}
@@ -144,6 +145,11 @@ function closeModal() {
 
 .tilePlant, .tileAnimal, .tileAssembly {
   font-size: 1.3em;
+}
+
+.tileAssembly.not-built {
+  font-size: 0.8em;
+  color: #b71c1c;
 }
 
 .tileStats {

--- a/src/components/subcomponents/mainMap/actions/assemblies/TransportAssembly.vue
+++ b/src/components/subcomponents/mainMap/actions/assemblies/TransportAssembly.vue
@@ -2,18 +2,89 @@
 import { modulesStore } from '/stores/modulesStore.js'
 import { tilesStore } from '/stores/tilesStore.js'
 import { computed, ref, watch, onMounted } from 'vue'
-import { assemblyMeetsRequirements } from '@/rules/utils.js'
+import { canAssemblyMoveAlone } from '@/rules/utils.js'
 
 const props = defineProps({
   assembly: Object
 })
 
+const modules = modulesStore()
+const tilesStoreInstance = tilesStore()
+const allTiles = computed(() => tilesStoreInstance.tiles.flat())
+const tile = computed(() => tilesStoreInstance.selectedSubject.value)
+
+const destinationValues = ref({})
+const selectedAssemblies = ref({})
+
+const transportableAssemblies = computed(() =>
+  modules.activeAssemblies.filter(
+    a => !a.deployed && !canAssemblyMoveAlone(a) && a.id !== props.assembly.id
+  )
+)
+
+function preselectDestination() {
+  if (destinationValues.value[props.assembly.id]) return
+  if (tile.value && tile.value.row != null && tile.value.col != null) {
+    destinationValues.value[props.assembly.id] = `${tile.value.row},${tile.value.col}`
+  } else {
+    destinationValues.value[props.assembly.id] = ''
+  }
+}
+onMounted(preselectDestination)
+watch(() => [tile.value?.row, tile.value?.col, props.assembly.id], preselectDestination)
+
+function transport() {
+  const destVal = destinationValues.value[props.assembly.id]
+  const selectedId = selectedAssemblies.value[props.assembly.id]
+  if (!props.assembly || !destVal || !selectedId) return
+
+  const idx = modules.activeAssemblies.findIndex(a => a.id === selectedId)
+  if (idx === -1) return
+  const [cargo] = modules.activeAssemblies.splice(idx, 1)
+
+  const [row, col] = destVal.split(',').map(Number)
+  if (row == null || col == null) return
+  const destTile = tilesStoreInstance.tiles[row][col]
+  destTile.assemblies = destTile.assemblies || []
+  destTile.assemblies.push(cargo)
+  cargo.deployed = true
+
+  props.assembly.moves = (props.assembly.moves || 1) - 1
+
+  destinationValues.value[props.assembly.id] = ''
+  selectedAssemblies.value[props.assembly.id] = ''
+}
 </script>
 
 <template>
-
+  <div>
+    <button
+      @click="transport"
+      :disabled="assembly.moves < 1 || !destinationValues[assembly.id] || !selectedAssemblies[assembly.id]"
+    >Transport Assembly</button>
+    <select v-model="selectedAssemblies[assembly.id]">
+      <option disabled value="">Select Assembly</option>
+      <option
+        v-for="a in transportableAssemblies"
+        :key="a.id"
+        :value="a.id"
+      >
+        {{ a.name || a.id }}
+      </option>
+    </select>
+    <select v-model="destinationValues[assembly.id]">
+      <option disabled value="">Destination</option>
+      <option
+        v-for="tileOption in allTiles"
+        :key="tileOption.row + '-' + tileOption.col"
+        :value="tileOption.row + ',' + tileOption.col"
+      >
+        {{ tileOption.row + 1 }},{{ tileOption.col + 1 }}
+      </option>
+    </select>
+    <span v-if="assembly.moves < 1" class="btn-error">No moves left for this assembly</span>
+  </div>
 </template>
 
 <style scoped>
-
 </style>


### PR DESCRIPTION
## Summary
- enable saving assemblies with built state determined by transport module presence
- add TransportAssembly action to deploy non-transport assemblies to tiles
- display unbuilt assemblies on tiles as "not built yet"

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a0630fba483279b4b457a4db84ad3